### PR TITLE
Fixing minor errors in spelling and grammar.

### DIFF
--- a/es/1/arrays.md
+++ b/es/1/arrays.md
@@ -50,7 +50,7 @@ string[5] stringArray;
 uint[] dynamicArray;
 ```
 
-Tambien puedes crear arrays de **_structuras_**. Si usásemos la estructura `Person` del capítulo anterior:
+También puedes crear arrays de **_estructuras_**. Si usásemos la estructura `Person` del capítulo anterior:
 
 ```
 Person[] people; // Array dinámico, podemos seguir añadiéndole elementos
@@ -66,10 +66,10 @@ Puedes declarar un array como `público`, y Solidity creará automaticamente una
 Person[] public people;
 ```
 
-Otros contratos podrían entonces leer (pero no escribir) de este array. Es un patrón de uso muy útil para guardar datos públicos en tu contrato.
+Otros contratos entonces podrán leer (pero no escribir) de este array. Es un patrón de uso muy útil para guardar datos públicos en tu contrato.
 
 # Vamos a probarlo
 
 Vamos a guardar un ejército de zombis en nuestra aplicación. Y vamos a querer mostrar todos nuestros zombis a otras applicaciones, así que lo queremos público:
 
-1. Crear un array público de **_structuras_** `Zombie` y llámalo `zombies`.
+1. Crea un array público de **_estructuras_** `Zombie` y llámalo `zombies`.


### PR DESCRIPTION
There were some minor misspelling problems and two grammar issues that made the reading feel a little bit off.  
About the change from  podría to podrán :
Otros contratos entonces podrán leer -It means that for sure other contracts will be able to read from the array.
Otros contratos entonces podría leer - It means that there is a chance that it could happen, but it may not work.

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
